### PR TITLE
Try more stable pos format for godoctor rename

### DIFF
--- a/godoctor.el
+++ b/godoctor.el
@@ -115,10 +115,15 @@
     (unless symbol
       (error "No symbol at point"))
     (let* ((compilation-buffer "*godoctor rename*")
-           (offset (point))
            (new-name (symbol-name symbol))
            (len (length new-name))
-           (pos (format "%d,%d" offset len))
+           (startrow (line-number-at-pos))
+           (startcol (current-column))
+           (endrow startrow)
+           (endcol (+ startcol (- len 1)))
+           (pos (format "%d,%d:%d,%d"
+                        startrow startcol
+                        endrow endcol))
            (new-name (read-string "New name: " new-name))
            (cmd (godoctor-rename-cmd pos new-name dry-run)))
       (godoctor--execute-command compilation-buffer cmd dry-run))))


### PR DESCRIPTION
```
-pos startrow,startcol:endrow,endcol
```

Previously,
```
-pos offset:length
```