### PR TITLE
Use -pos <offset,length> for rename.

### DIFF
--- a/godoctor.el
+++ b/godoctor.el
@@ -1,6 +1,6 @@
 ;;; godoctor.el --- Frontend for godoctor
 
-;; Copyright (C) 2016 james sangho nah <microamp@protonmail.com>
+;; Copyright (C) 2016, 2018 james sangho nah <microamp@protonmail.com>
 ;;
 ;; Author: james sangho nah <microamp@protonmail.com>
 ;; Version: 0.0.9
@@ -117,13 +117,7 @@
     (let* ((compilation-buffer "*godoctor rename*")
            (new-name (symbol-name symbol))
            (len (length new-name))
-           (startrow (line-number-at-pos))
-           (startcol (current-column))
-           (endrow startrow)
-           (endcol (+ startcol (- len 1)))
-           (pos (format "%d,%d:%d,%d"
-                        startrow startcol
-                        endrow endcol))
+           (pos (format "%d,%d" (point) len))
            (new-name (read-string "New name: " new-name))
            (cmd (godoctor-rename-cmd pos new-name dry-run)))
       (godoctor--execute-command compilation-buffer cmd dry-run))))


### PR DESCRIPTION
The -pos <startrow,startcol:endrow,endcol> argument does not work for structure fields with camelCase names. Using -pos <offset,length> seems to work fine.